### PR TITLE
update tests node version to support package-lock v2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v1
       with:
-        node-version: 12
+        node-version: 16
     - name: Install dependencies
       run: npm ci
     - name: Run tests

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "aframe-physics-system",
-  "version": "4.0.1",
+  "name": "@c-frame/aframe-physics-system",
+  "version": "4.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "aframe-physics-system",
-      "version": "4.0.1",
+      "name": "@c-frame/aframe-physics-system",
+      "version": "4.1.0",
       "license": "MIT",
       "dependencies": {
         "ammo-debug-drawer": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -82,5 +82,8 @@
     "example": "examples",
     "lib": "lib",
     "test": "tests"
+  },
+  "engines": {
+    "npm": ">=7"
   }
 }


### PR DESCRIPTION
Recently package-lock was updated to v2 and tests are failing on npm install
* Update node version for tests to 16 to include npm >=7 with support for lock v2
* Add engines field to package.json to document requirement
* Also I got a diff in package-lock after install due to the package name being previously updated in package.json, commit this change