### PR TITLE
Fix pushing direction

### DIFF
--- a/examples/components/force-pushable.js
+++ b/examples/components/force-pushable.js
@@ -58,7 +58,9 @@ AFRAME.registerComponent('force-pushable', {
     const el = this.el
     const force = this.force
     const impulseBt = this.impulseBtVector
-    force.copy(el.object3D.position)
+    const pusher = e.detail.cursorEl.object3D
+    pusher.localToWorld(pusher.position)
+    force.copy(el.object3D.position.sub(pusher.position))
     force.normalize();
 
     // not sure about units, but force seems much stronger with Ammo than Cannon, so scaling down


### PR DESCRIPTION
In [Ammo's force-pushable example](https://c-frame.github.io/aframe-physics-system/examples/ammo/stress.html), wherever I click an object, the force comes from (0, 0, 0). 

I added vector subtraction to direct force from the clicker to the object. Also, this code works if cursor is mouse.