### PR TITLE
Handle the case where mesh2shape returns null

### DIFF
--- a/src/components/body/body.js
+++ b/src/components/body/body.js
@@ -71,12 +71,17 @@ var Body = {
         type: ShapeType[data.shape.toUpperCase()]
       });
 
-      var { shape, offset, orientation } = mesh2shape(this.el.object3D, options);
+      const shapeInfo = mesh2shape(this.el.object3D, options);
+      let shape, offset, orientation;
+      if (shapeInfo) {
+        ({ shape, offset, orientation } = shapeInfo);
+      }
 
       if (!shape) {
         el.addEventListener('object3dset', this.initBody.bind(this));
         return;
       }
+
       this.body.addShape(shape, offset, orientation);
 
       // Show wireframe


### PR DESCRIPTION
This can happen, for instance, when a gltf-model has not finished loading, hence a bounding box cannot be calculated. We try again after the object3D has been set in this case, the same as when "shape" is missing.
