### PR TITLE
Fix force-pushable example for the ammo driver

### DIFF
--- a/examples/components/force-pushable.js
+++ b/examples/components/force-pushable.js
@@ -59,13 +59,12 @@ AFRAME.registerComponent('force-pushable', {
     const force = this.force
     const impulseBt = this.impulseBtVector
     const pusher = e.detail.cursorEl.object3D
-    pusher.localToWorld(pusher.position)
-    force.copy(el.object3D.position.sub(pusher.position))
+    force.copy(pusher.position)
+    pusher.localToWorld(force)
+    force.copy(el.object3D.position.sub(force))
     force.normalize();
 
-    // not sure about units, but force seems much stronger with Ammo than Cannon, so scaling down
-    // by a factor of 10.
-    force.multiplyScalar(this.data.force / 10);
+    force.multiplyScalar(this.data.force);
     impulseBt.setValue(force.x, force.y, force.z)
 
     // use data from intersection to determine point at which to apply impulse.


### PR DESCRIPTION
This fixes https://c-frame.github.io/aframe-physics-system/examples/ammo/compound.html, where currently the cursor will disappear upon clicking. This is because its position will be converted from world to local on the position itself, rather than on a slack vector. I have used the force vector because it was already there.

I have also removed the dampening on the force, as this seems to not be necessary (the impulse is actually rather weak now).