### PR TITLE
Do not destroy bodyTransform

### DIFF
--- a/src/components/ammo-constraint.js
+++ b/src/components/ammo-constraint.js
@@ -166,7 +166,6 @@ module.exports = AFRAME.registerComponent("ammo-constraint", {
         throw new Error("[constraint] Unexpected type: " + data.type);
     }
 
-    Ammo.destroy(bodyTransform);
     Ammo.destroy(targetTransform);
 
     return constraint;


### PR DESCRIPTION
this is in fact the btTranform returned by .getCenterOfMassTransform, that is, protected member m_worldTransform of the btCollisionObject class and not an object instantiated locally

Deleting this object will eventually lead to an out of bound access error that will prevent any further constraint

See https://pybullet.org/Bullet/BulletFull/classbtRigidBody.html#a5eaee89e89e7498cfb39709e58fdc477

I also attach a toy example where I continuously toggle a constraint between an object and the camera and a screenshot of the error.

![Error Screenshot](https://github.com/c-frame/aframe-physics-system/assets/3331940/14a581d2-4747-40aa-8fdf-ad49374e4dff)
[toy-example.zip](https://github.com/c-frame/aframe-physics-system/files/12851124/toy-example.zip)
