### PR TITLE
Use null instead of an object with undefined properties

### DIFF
--- a/src/components/body/ammo-body.js
+++ b/src/components/body/ammo-body.js
@@ -46,7 +46,7 @@ let AmmoBody = {
   schema: {
     loadedEvent: { default: "" },
     mass: { default: 1 },
-    gravity: { type: "vec3", default: { x: undefined, y: undefined, z: undefined } },
+    gravity: { type: "vec3", default: null },
     linearDamping: { default: 0.01 },
     angularDamping: { default: 0.01 },
     linearSleepingThreshold: { default: 1.6 },


### PR DESCRIPTION
This will be coalesced to an empty object, which keeps the expected behavior. The previous default would trigger a warning in the console about it not being conform to the vec3 property type definition.

Warning is:

core:schema:warn Default value `[object Object]` does not match type `vec3` in component `ammo-body` 