### PR TITLE
Revert to aframe 1.5.0 for examples using the stats panel

### DIFF
--- a/examples/ammo/perf.html
+++ b/examples/ammo/perf.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>Physics Benchmark Test - Ammo</title>
     <meta name="description" content="Physics Benchamrk Test - Ammo">
-    <script src="https://aframe.io/releases/1.7.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.5.0/aframe.min.js"></script>
     <script src="https://cdn.jsdelivr.net/gh/MozillaReality/ammo.js@8bbc0ea/builds/ammo.wasm.js"></script>
     <script src="../../dist/aframe-physics-system.js"></script>
     <script src="../components/pinboard.js"></script>

--- a/examples/ammo/stress.html
+++ b/examples/ammo/stress.html
@@ -4,7 +4,7 @@
     <meta http-equiv="content-type" content="text/html; charset=utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no,user-scalable=no,maximum-scale=1">
     <title>Examples • Stress Test AMMO</title>
-    <script src="https://aframe.io/releases/1.7.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.5.0/aframe.min.js"></script>
     <script src="https://unpkg.com/aframe-environment-component@1.4.0/dist/aframe-environment-component.min.js"></script>
     <script src="https://cdn.jsdelivr.net/gh/MozillaReality/ammo.js@8bbc0ea/builds/ammo.wasm.js"></script>
     <script src="../../dist/aframe-physics-system.js"></script>

--- a/examples/ammo/sweeper.html
+++ b/examples/ammo/sweeper.html
@@ -4,7 +4,7 @@
     <meta http-equiv="content-type" content="text/html; charset=utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no,user-scalable=no,maximum-scale=1">
     <title>Examples • Sweeper AMMO</title>
-    <script src="https://aframe.io/releases/1.7.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.5.0/aframe.min.js"></script>
     <script src="https://unpkg.com/aframe-environment-component@1.4.0/dist/aframe-environment-component.min.js"></script>
     <script src="https://cdn.jsdelivr.net/gh/MozillaReality/ammo.js@8bbc0ea/builds/ammo.wasm.js"></script>
     <script src="../../dist/aframe-physics-system.js"></script>

--- a/examples/cannon-worker/perf.html
+++ b/examples/cannon-worker/perf.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>Physics Benchmark Test - Cannon</title>
     <meta name="description" content="Physics Benchamrk Test - Cannon Worker">
-    <script src="https://aframe.io/releases/1.7.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.5.0/aframe.min.js"></script>
     <script src="../../dist/aframe-physics-system.js"></script>
     <script src="../components/pinboard.js"></script>
     <link rel="stylesheet" href="../styles.css">

--- a/examples/cannon-worker/stress.html
+++ b/examples/cannon-worker/stress.html
@@ -4,7 +4,7 @@
     <meta http-equiv="content-type" content="text/html; charset=utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no,user-scalable=no,maximum-scale=1">
     <title>Examples • Stress Test CANNON Worker</title>
-    <script src="https://aframe.io/releases/1.7.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.5.0/aframe.min.js"></script>
     <script src="https://unpkg.com/aframe-environment-component@1.4.0/dist/aframe-environment-component.min.js"></script>
     <script src="../../dist/aframe-physics-system.js"></script>
     <script src="../components/force-pushable.js"></script>

--- a/examples/cannon-worker/sweeper.html
+++ b/examples/cannon-worker/sweeper.html
@@ -4,7 +4,7 @@
     <meta http-equiv="content-type" content="text/html; charset=utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no,user-scalable=no,maximum-scale=1">
     <title>Examples • Sweeper CANNON Worker</title>
-    <script src="https://aframe.io/releases/1.7.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.5.0/aframe.min.js"></script>
     <script src="https://unpkg.com/aframe-environment-component@1.4.0/dist/aframe-environment-component.min.js"></script>
     <script src="../../dist/aframe-physics-system.js"></script>
     <script src="../components/grab.js"></script>

--- a/examples/cannon/perf.html
+++ b/examples/cannon/perf.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>Physics Benchmark Test - Cannon</title>
     <meta name="description" content="Physics Benchamrk Test - Cannon">
-    <script src="https://aframe.io/releases/1.7.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.5.0/aframe.min.js"></script>
     <script src="../../dist/aframe-physics-system.js"></script>
     <script src="../components/pinboard.js"></script>
     <link rel="stylesheet" href="../styles.css">

--- a/examples/cannon/stress.html
+++ b/examples/cannon/stress.html
@@ -4,7 +4,7 @@
     <meta http-equiv="content-type" content="text/html; charset=utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no,user-scalable=no,maximum-scale=1">
     <title>Examples • Stress Test CANNON</title>
-    <script src="https://aframe.io/releases/1.7.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.5.0/aframe.min.js"></script>
     <script src="https://unpkg.com/aframe-environment-component@1.4.0/dist/aframe-environment-component.min.js"></script>
     <script src="../../dist/aframe-physics-system.js"></script>
     <script src="../components/force-pushable.js"></script>

--- a/examples/cannon/sweeper.html
+++ b/examples/cannon/sweeper.html
@@ -4,7 +4,7 @@
     <meta http-equiv="content-type" content="text/html; charset=utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no,user-scalable=no,maximum-scale=1">
     <title>Examples • Sweeper CANNON</title>
-    <script src="https://aframe.io/releases/1.7.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.5.0/aframe.min.js"></script>
     <script src="https://unpkg.com/aframe-environment-component@1.4.0/dist/aframe-environment-component.min.js"></script>
     <script src="../../dist/aframe-physics-system.js"></script>
     <script src="../components/grab.js"></script>


### PR DESCRIPTION
Revert to aframe 1.5.0 for examples using the stats panel for now because of an error in stats-collector component
`this.data.properties` is undefined here
https://github.com/diarmidmackenzie/aframe-components/blob/dc1eebbe9dccfad1110158a5420ead384576f58c/components/stats-panel/index.js#L215